### PR TITLE
エラーアラートが表示されないバグを修正

### DIFF
--- a/Example/Example/Model/WeatherModel.swift
+++ b/Example/Example/Model/WeatherModel.swift
@@ -41,16 +41,19 @@ class WeatherModelImpl: WeatherModel {
     
     func fetchWeather(at area: String, date: Date, completion: @escaping (Result<Response, WeatherError>) -> Void) {
         let request = Request(area: area, date: date)
-        if let requestJson = try? jsonString(from: request) {
-            DispatchQueue.global().async {
-                if let responseJson = try? YumemiWeather.syncFetchWeather(requestJson) {
-                    if let response = try? self.response(from: responseJson) {
-                        completion(.success(response))
-                    }
-                    else {
-                        completion(.failure(WeatherError.jsonDecodeError))
-                    }
-                }
+        guard let requestJson = try? jsonString(from: request) else {
+            completion(.failure(WeatherError.jsonEncodeError))
+            return
+        }
+        DispatchQueue.global().async {
+            guard let responseJson = try? YumemiWeather.syncFetchWeather(requestJson) else {
+                completion(.failure(WeatherError.unknownError))
+                return
+            }
+            if let response = try? self.response(from: responseJson) {
+                completion(.success(response))
+            } else {
+                completion(.failure(WeatherError.jsonDecodeError))
             }
         }
     }


### PR DESCRIPTION
## 概要
[session14](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/BugFix.md)
#2 

## やったこと
- WeatherModelのクロージャが呼ばれず、エラーアラートが表示されていなかったので、completionを追加してアラートを表示されるようにしました。
- ~~クローズボタンタップ後、再度天気画面が表示されたときに天気が表示されるようにviewDidLoadにメソッドを追加して表示されるようにしました。~~
- ~~アラートを表示後にバックグラウンドからフォアグラウンドに移動した後にアラートの背後で天気が更新されていたので、アラートを閉じました。~~
- ~~テストコードがパスするように修正~~

## 挙動
iPhone13

https://user-images.githubusercontent.com/66917548/169226118-a76597c5-064d-454e-be67-0ac1170d591b.mp4








