### PR TITLE
テストがパスしない不具合を修正

### DIFF
--- a/Example/ExampleTests/WeatherViewControllerTests.swift
+++ b/Example/ExampleTests/WeatherViewControllerTests.swift
@@ -87,10 +87,6 @@ class WeatherModelMock: WeatherModel {
         completion(.success(response))
     }
     
-    func fetchWeather(_ request: Request) throws -> Response {
-        return try fetchWeatherImpl(request)
-    }
-    
 }
 
 class DisasterModelMock: DisasterModel {

--- a/Example/ExampleTests/WeatherViewControllerTests.swift
+++ b/Example/ExampleTests/WeatherViewControllerTests.swift
@@ -12,66 +12,91 @@ import YumemiWeather
 
 class WeatherViewControllerTests: XCTestCase {
 
-    var weahterViewController: WeatherViewController!
-    var weahterModel: WeatherModelMock!
+    private var weatherViewController: WeatherViewController!
+    private var weatherModel: WeatherModelMock!
+    private var disasterModel: DisasterModelMock!
     
     override func setUpWithError() throws {
-        weahterModel = WeatherModelMock()
-        weahterViewController = R.storyboard.weather.instantiateInitialViewController()!
-        weahterViewController.weatherModel = weahterModel
-        _ = weahterViewController.view
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        weatherModel = WeatherModelMock()
+        disasterModel = DisasterModelMock()
+        weatherViewController = R.storyboard.weather.instantiateInitialViewController()!
+        weatherViewController.weatherModel = weatherModel
+        weatherViewController.disasterModel = disasterModel
+        _ = weatherViewController.view
     }
 
     func test_天気予報がsunnyだったらImageViewのImageにsunnyが設定されること_TintColorがredに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .sunny, maxTemp: 0, minTemp: 0, date: Date())
         }
-        
-        weahterViewController.loadWeather()
-        XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.red())
-        XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.sunny())
+        weatherViewController.loadWeather(nil)
+        waitUntilUISet()
+        XCTAssertEqual(weatherViewController.weatherImageView.tintColor, R.color.red())
+        XCTAssertEqual(weatherViewController.weatherImageView.image, R.image.sunny())
     }
     
     func test_天気予報がcloudyだったらImageViewのImageにcloudyが設定されること_TintColorがgrayに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .cloudy, maxTemp: 0, minTemp: 0, date: Date())
         }
-        
-        weahterViewController.loadWeather()
-        XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.gray())
-        XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.cloudy())
+        weatherViewController.loadWeather(nil)
+        waitUntilUISet()
+        XCTAssertEqual(weatherViewController.weatherImageView.tintColor, R.color.gray())
+        XCTAssertEqual(weatherViewController.weatherImageView.image, R.image.cloudy())
     }
     
     func test_天気予報がrainyだったらImageViewのImageにrainyが設定されること_TintColorがblueに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .rainy, maxTemp: 0, minTemp: 0, date: Date())
         }
-        
-        weahterViewController.loadWeather()
-        XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.blue())
-        XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.rainy())
+        weatherViewController.loadWeather(nil)
+        waitUntilUISet()
+        XCTAssertEqual(weatherViewController.weatherImageView.tintColor, R.color.blue())
+        XCTAssertEqual(weatherViewController.weatherImageView.image, R.image.rainy())
     }
     
     func test_最高気温_最低気温がUILabelに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .rainy, maxTemp: 100, minTemp: -100, date: Date())
         }
-        
-        weahterViewController.loadWeather()
-        XCTAssertEqual(weahterViewController.minTempLabel.text, "-100")
-        XCTAssertEqual(weahterViewController.maxTempLabel.text, "100")
+        weatherViewController.loadWeather(nil)
+        waitUntilUISet()
+        XCTAssertEqual(weatherViewController.minTempLabel.text, "-100")
+        XCTAssertEqual(weatherViewController.maxTempLabel.text, "100")
     }
+    
+    private func waitUntilUISet() {
+        let expectation = expectation(description: "test")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 3)
+    }
+    
 }
 
 class WeatherModelMock: WeatherModel {
     
     var fetchWeatherImpl: ((Request) throws -> Response)!
     
+    func fetchWeather(at area: String,
+                      date: Date,
+                      completion: @escaping (Result<Response, WeatherError>) -> Void) {
+        let request = Request(area: area, date: date)
+        let response = try! fetchWeatherImpl(request)
+        completion(.success(response))
+    }
+    
     func fetchWeather(_ request: Request) throws -> Response {
         return try fetchWeatherImpl(request)
     }
+    
+}
+
+class DisasterModelMock: DisasterModel {
+    
+    func fetchDisaster(completion: ((String) -> Void)?) {
+        completion?("")
+    }
+    
 }


### PR DESCRIPTION
## 概要
[session14](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/BugFix.md)
#3 

## やったこと
UIが初期設定される前にXCTAssertEqualが実行されていたので、waitUntilUISetメソッドを追加し、UIが設定されるまで待つ処理を記述しました。