### PR TITLE
アラート表示後にバックグラウンドに移動したときにアラートの背後で天気が更新される不具合を修正

### DIFF
--- a/Example/Example/Model/WeatherModel.swift
+++ b/Example/Example/Model/WeatherModel.swift
@@ -56,5 +56,6 @@ class WeatherModelImpl: WeatherModel {
                 completion(.failure(WeatherError.jsonDecodeError))
             }
         }
+        
     }
 }

--- a/Example/Example/UI/Weather/WeatherViewController.swift
+++ b/Example/Example/UI/Weather/WeatherViewController.swift
@@ -20,6 +20,7 @@ class WeatherViewController: UIViewController {
     
     var weatherModel: WeatherModel!
     var disasterModel: DisasterModel!
+    private var alertController: UIAlertController?
     @IBOutlet weak var weatherImageView: UIImageView!
     @IBOutlet weak var minTempLabel: UILabel!
     @IBOutlet weak var maxTempLabel: UILabel!
@@ -32,6 +33,12 @@ class WeatherViewController: UIViewController {
         NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [unowned self] notification in
             self.loadWeather(notification.object)
         }
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(closeAlert),
+                                               name: UIApplication.willResignActiveNotification,
+                                               object: nil)
+        
+        
     }
     
     deinit {
@@ -79,9 +86,16 @@ class WeatherViewController: UIViewController {
                     print("Close ViewController by \(alertController)")
                 }
             })
+            self.alertController = alertController
             self.present(alertController, animated: true, completion: nil)
         }
     }
+    
+    @objc private func closeAlert() {
+        alertController?.dismiss(animated: true)
+        alertController = nil
+    }
+    
 }
 
 private extension UIImageView {


### PR DESCRIPTION
## 概要
[session14](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/BugFix.md)
#4 

## やったこと
アラートが表示された状態でバックグラウンドに行き、フォアグラウンドに戻るとアラートが表示されたままアラートの背後で天気が更新されていたので、アラートを閉じて天気が更新されるようにしました。

## 挙動
iPhone13

https://user-images.githubusercontent.com/66917548/169500058-a74fb0f0-56af-4670-ae9f-f72010131524.mp4


