### PR TITLE
WeatherViewControllerのdeinitが呼ばれない不具合を修正しました。

### DIFF
--- a/Example/Example/UI/Weather/WeatherViewController.swift
+++ b/Example/Example/UI/Weather/WeatherViewController.swift
@@ -44,14 +44,16 @@ class WeatherViewController: UIViewController {
     
     @IBAction func loadWeather(_ sender: Any?) {
         self.activityIndicator.startAnimating()
-        weatherModel.fetchWeather(at: "tokyo", date: Date()) { result in
+        weatherModel.fetchWeather(at: "tokyo", date: Date()) { [weak self] result in
+            guard let strongSelf = self else { return }
             DispatchQueue.main.async {
-                self.activityIndicator.stopAnimating()
-                self.handleWeather(result: result)
+                strongSelf.activityIndicator.stopAnimating()
+                strongSelf.handleWeather(result: result)
             }
         }
-        disasterModel.fetchDisaster { (disaster) in
-            self.disasterLabel.text = disaster
+        disasterModel.fetchDisaster { [weak self] (disaster) in
+            guard let strongSelf = self else { return }
+            strongSelf.disasterLabel.text = disaster
         }
     }
     


### PR DESCRIPTION
## 概要
[session14](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/BugFix.md)
#7 

## やったこと
WeatherViewControllerのloadWeatherのfetchをしている箇所で弱参照にしてメモリが解放されるようにしました。